### PR TITLE
Ver1.1 feature win app on resize

### DIFF
--- a/project/engine/base/TakoFramework.cpp
+++ b/project/engine/base/TakoFramework.cpp
@@ -15,7 +15,7 @@
 void TakoFramework::Initialize()
 {
 #pragma region ウィンドウの初期化-------------------------------------------------------------------------------------------------------------------
-	winApp_ = new WinApp();
+  winApp_ = WinApp::GetInstance();
 	winApp_->Initialize();
 #pragma endregion
 
@@ -113,9 +113,6 @@ void TakoFramework::Finalize()
 	delete sceneFactory_;
 
 	winApp_->Finalize();
-
-	// ウィンドウクラスの解放
-	delete winApp_;
 }
 
 void TakoFramework::Update()

--- a/project/engine/base/WinApp.cpp
+++ b/project/engine/base/WinApp.cpp
@@ -7,6 +7,9 @@
 #include"imgui_impl_win32.h"
 extern IMGUI_IMPL_API LRESULT ImGui_ImplWin32_WndProcHandler(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
 
+// instanceの初期化
+WinApp* WinApp::instance_ = nullptr;
+
 std::vector<IWndProcHandler*> WinApp::m_handlers_;
 
 int32_t WinApp::clientWidth = 1280;
@@ -190,10 +193,24 @@ void WinApp::ToggleFullScreen()
   }
 }
 
-void WinApp::UnregisterOnResizeFunc(const std::function<void(Vector2)>& onResizeFunc)
+void WinApp::RegisterOnResizeFunc(void(* onResizeFunc)(Vector2))
 {
-  auto it = std::remove(onResizeFuncs_.begin(), onResizeFuncs_.end(), onResizeFunc);
-  if (it != onResizeFuncs_.end()) {
-    onResizeFuncs_.erase(it, onResizeFuncs_.end());
+  // 重複登録を防ぐために、すでに登録されているか確認
+  auto it = std::ranges::find(onResizeFuncs_, onResizeFunc);
+  if (it != onResizeFuncs_.end())
+  {
+    // すでに登録されている場合は何もしない
+    return;
+  }
+  onResizeFuncs_.push_back(onResizeFunc);
+}
+
+void WinApp::UnregisterOnResizeFunc(void(*onResizeFunc)(Vector2))
+{
+  // 指定された関数ポインタを削除
+  auto it = std::ranges::find(onResizeFuncs_, onResizeFunc);
+  if (it != onResizeFuncs_.end())
+  {
+    onResizeFuncs_.erase(it);
   }
 }

--- a/project/engine/base/WinApp.cpp
+++ b/project/engine/base/WinApp.cpp
@@ -2,6 +2,7 @@
 
 #include "WinApp.h"
 
+#include <algorithm>
 #include <cassert>
 #include"imgui_impl_win32.h"
 extern IMGUI_IMPL_API LRESULT ImGui_ImplWin32_WndProcHandler(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
@@ -78,14 +79,19 @@ bool WinApp::ProcessMessage()
 	return false;
 }
 
-
-
 void WinApp::Finalize()
 {
 	//ウィンドウを破棄
 	CloseWindow(hWnd_);
 	// COMの終了処理
 	CoUninitialize();
+
+  // instance_削除
+  if (instance_ != nullptr)
+  {
+    delete instance_;
+    instance_ = nullptr;
+  }
 }
 
 LRESULT WinApp::WndProc(HWND hWnd, UINT msg, WPARAM wparam, LPARAM lparam)
@@ -171,5 +177,23 @@ void WinApp::ToggleFullScreen()
 
     // 状態を更新
     isFullScreen_ = false;
+  }
+
+  // OnResize関数があれば呼び出す
+  if (!onResizeFuncs_.empty())
+  {
+    Vector2 newSize = { .x= static_cast<float>(clientWidth), .y= static_cast<float>(clientHeight) };
+    for (const auto& onResizeFunc : onResizeFuncs_)
+    {
+      onResizeFunc(newSize);
+    }
+  }
+}
+
+void WinApp::UnregisterOnResizeFunc(const std::function<void(Vector2)>& onResizeFunc)
+{
+  auto it = std::remove(onResizeFuncs_.begin(), onResizeFuncs_.end(), onResizeFunc);
+  if (it != onResizeFuncs_.end()) {
+    onResizeFuncs_.erase(it, onResizeFuncs_.end());
   }
 }

--- a/project/engine/base/WinApp.h
+++ b/project/engine/base/WinApp.h
@@ -2,12 +2,10 @@
 #include<Windows.h>
 #include<cstdint>
 #include <functional>
-
-#include "IWndProcHandler.h"
 #include <vector>
 
+#include "IWndProcHandler.h"
 #include "Vector2.h"
-
 
 class WinApp {
 private: // シングルトン設定
@@ -15,6 +13,7 @@ private: // シングルトン設定
   static WinApp* instance_;
   WinApp() = default;
   ~WinApp() = default;
+
 public:
   // コピーコンストラクタと代入演算子を削除
   WinApp(const WinApp&) = delete;
@@ -27,7 +26,8 @@ public:
     }
     return instance_;
   }
-public:
+
+public: // メンバ関数
   /// <summary>
   /// 初期化
   /// </summary>
@@ -83,13 +83,13 @@ public:
   /// OnResize関数の登録
   /// <summary>
   /// <param name="onResizeFunc"></param>
-  void RegisterOnResizeFunc(const std::function<void(Vector2)>& onResizeFunc) { onResizeFuncs_.push_back(onResizeFunc); }
+  void RegisterOnResizeFunc(void(*onResizeFunc)(Vector2));
 
   /// <summary>
   /// OnResize関数の削除
   /// <summary>
   /// <param name="onResizeFunc"></param>
-  void UnregisterOnResizeFunc(const std::function<void(Vector2)>& onResizeFunc);
+  void UnregisterOnResizeFunc(void(*onResizeFunc)(Vector2));
 
 public:
   //クライアント領域のサイズ
@@ -112,6 +112,6 @@ private:
   // ウィンドウモード時の位置とサイズを保存
   RECT windowedRect_ = {};
 
-  // Onresize関数ポインターの配列
-  std::vector<std::function<void(Vector2)>> onResizeFuncs_;
+  // OnResize関数ポインターの配列
+  std::vector<void(*)(Vector2)> onResizeFuncs_;
 };

--- a/project/engine/base/WinApp.h
+++ b/project/engine/base/WinApp.h
@@ -1,41 +1,62 @@
 #pragma once
 #include<Windows.h>
 #include<cstdint>
+#include <functional>
+
 #include "IWndProcHandler.h"
 #include <vector>
 
+#include "Vector2.h"
+
 
 class WinApp {
+private: // シングルトン設定
+  // シングルトンインスタンス
+  static WinApp* instance_;
+  WinApp() = default;
+  ~WinApp() = default;
 public:
-	/// <summary>
-	/// 初期化
-	/// </summary>
-	void Initialize();
+  // コピーコンストラクタと代入演算子を削除
+  WinApp(const WinApp&) = delete;
+  WinApp& operator=(const WinApp&) = delete;
 
-	/// <summary>
-	/// メッセージの処理
-	/// </summary>
-	bool ProcessMessage();
+  // シングルトンインスタンスの取得
+  static WinApp* GetInstance() {
+    if (instance_ == nullptr) {
+      instance_ = new WinApp();
+    }
+    return instance_;
+  }
+public:
+  /// <summary>
+  /// 初期化
+  /// </summary>
+  void Initialize();
 
-	/// <summary>
-	/// 終了処理
-	/// </summary>
-	void Finalize();
+  /// <summary>
+  /// メッセージの処理
+  /// </summary>
+  bool ProcessMessage();
 
-	/// <summary>
-	/// ウィンドウプロシージャ
-	/// </summary>
-	static LRESULT CALLBACK WndProc(HWND hWnd, UINT msg, WPARAM wparam, LPARAM lparam);
+  /// <summary>
+  /// 終了処理
+  /// </summary>
+  void Finalize();
 
-	/// <summary>
-	/// ウィンドウハンドルの取得
-	/// </summary>
-	HWND GetHWnd() const { return hWnd_; }
+  /// <summary>
+  /// ウィンドウプロシージャ
+  /// </summary>
+  static LRESULT CALLBACK WndProc(HWND hWnd, UINT msg, WPARAM wparam, LPARAM lparam);
 
-	/// <summary>
-	/// hInstanceの取得
-	/// </summary>
-	HINSTANCE GetHInstance() const { return wc_.hInstance; }
+  /// <summary>
+  /// ウィンドウハンドルの取得
+  /// </summary>
+  HWND GetHWnd() const { return hWnd_; }
+
+  /// <summary>
+  /// hInstanceの取得
+  /// </summary>
+  HINSTANCE GetHInstance() const { return wc_.hInstance; }
 
   /// <summary>
   /// ハンドラの設定
@@ -53,21 +74,34 @@ public:
   /// </summary>
   void ToggleFullScreen();
 
-
-  // フルスクリーン状態の取得
+  /// <summary>
+  /// フルスクリーン状態の取得
+  /// </summary>
   bool IsFullScreen() const { return isFullScreen_; }
 
+  /// <summary>
+  /// OnResize関数の登録
+  /// <summary>
+  /// <param name="onResizeFunc"></param>
+  void RegisterOnResizeFunc(const std::function<void(Vector2)>& onResizeFunc) { onResizeFuncs_.push_back(onResizeFunc); }
+
+  /// <summary>
+  /// OnResize関数の削除
+  /// <summary>
+  /// <param name="onResizeFunc"></param>
+  void UnregisterOnResizeFunc(const std::function<void(Vector2)>& onResizeFunc);
+
 public:
-	//クライアント領域のサイズ
+  //クライアント領域のサイズ
   static int32_t clientWidth;
-	static int32_t clientHeight;
+  static int32_t clientHeight;
 
 private:
-	//ウィンドウハンドル
-	HWND hWnd_ = nullptr;
+  //ウィンドウハンドル
+  HWND hWnd_ = nullptr;
 
-	//ウィンドウクラス
-	WNDCLASS wc_{};
+  //ウィンドウクラス
+  WNDCLASS wc_{};
 
   // handlers
   static std::vector<IWndProcHandler*> m_handlers_;
@@ -77,4 +111,7 @@ private:
 
   // ウィンドウモード時の位置とサイズを保存
   RECT windowedRect_ = {};
+
+  // Onresize関数ポインターの配列
+  std::vector<std::function<void(Vector2)>> onResizeFuncs_;
 };

--- a/project/engine/effect/PostEffect.h
+++ b/project/engine/effect/PostEffect.h
@@ -14,6 +14,8 @@ private:
 
   PostEffect() = default;
   ~PostEffect() = default;
+
+public:
   PostEffect(PostEffect&) = delete;
   PostEffect& operator=(PostEffect&) = delete;
 


### PR DESCRIPTION
This pull request introduces a singleton pattern for the `WinApp` class, enhances its functionality with resize event handling, and updates the `TakoFramework` to align with these changes. Below are the most important changes grouped by theme:

### Singleton Implementation for `WinApp`:
* Converted `WinApp` into a singleton by adding a static `instance_` member, a private constructor, and a `GetInstance` method to ensure a single instance throughout the application. The copy constructor and assignment operator were deleted to enforce the singleton pattern. (`project/engine/base/WinApp.cpp`, `project/engine/base/WinApp.h`) [[1]](diffhunk://#diff-e81103992d17f23b9899ce2962345359f91e18677c23651cde64c785f606baa4R5-R12) [[2]](diffhunk://#diff-829985afd6c222b79a8f6276020a6c378c05cfe5db5f1b95baa1247e09c1ddafL4-R30)

### Memory Management Updates:
* Updated `TakoFramework` to use the singleton `WinApp` instance instead of creating and deleting it manually. The `delete winApp_` call was removed from the `Finalize` method. (`project/engine/base/TakoFramework.cpp`) [[1]](diffhunk://#diff-82a845ead567187162a8f45a865f3df5282e8178a5ed379d23bf1e96d5bfeaddL18-R18) [[2]](diffhunk://#diff-82a845ead567187162a8f45a865f3df5282e8178a5ed379d23bf1e96d5bfeaddL116-L118)
* Added logic in `WinApp::Finalize` to delete the singleton instance (`instance_`) when the application shuts down. (`project/engine/base/WinApp.cpp`)

### Resize Event Handling:
* Introduced methods `RegisterOnResizeFunc` and `UnregisterOnResizeFunc` in `WinApp` to allow registering and unregistering callback functions for resize events. These callbacks are invoked during `ToggleFullScreen` when the window size changes. (`project/engine/base/WinApp.cpp`, `project/engine/base/WinApp.h`) [[1]](diffhunk://#diff-e81103992d17f23b9899ce2962345359f91e18677c23651cde64c785f606baa4R184-R215) [[2]](diffhunk://#diff-829985afd6c222b79a8f6276020a6c378c05cfe5db5f1b95baa1247e09c1ddafL56-R93) [[3]](diffhunk://#diff-829985afd6c222b79a8f6276020a6c378c05cfe5db5f1b95baa1247e09c1ddafR114-R116)

### Code Cleanup:
* Removed redundant blank lines and improved code organization in `WinApp.cpp`. (`project/engine/base/WinApp.cpp`)
* Updated comments and documentation for better clarity, including adding XML-style documentation for new methods. (`project/engine/base/WinApp.h`)

### Minor Updates:
* Added `#include <algorithm>` for using STL algorithms in `WinApp.cpp`. (`project/engine/base/WinApp.cpp`)
* Ensured the `PostEffect` class follows the rule of five by deleting its copy constructor and assignment operator. (`project/engine/effect/PostEffect.h`)